### PR TITLE
Add in Travis configuration for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: false
+language: perl
+perl:
+   - 'blead'
+   - '5.22'
+   - '5.20'
+   - '5.18'
+   - '5.16'
+   - '5.14'
+   - '5.12'
+   - '5.10'
+   - '5.8'
+matrix:
+   allow_failures:
+      - perl: 'blead'
+      - perl: '5.8'
+   fast_finish: true
+before_install:
+   - git config --global user.name "TravisCI"
+   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
+install:
+   - cpanm --quiet --notest --skip-satisfied Dist::Zilla
+   - "dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest"
+   - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose"
+script:
+   - dzil smoke --release --author

--- a/dist.ini
+++ b/dist.ini
@@ -85,4 +85,4 @@ run                 = %x -Ilib maint%pbranch_dist.pl %v %d
 push_to             = origin
 push_to             = origin HEAD:refs/heads/release
 remotes_must_exist  = 0
-
+[TravisYML]


### PR DESCRIPTION
 Any fork just needs to configure their repo with travis-ci.org and can then run the test
suite against multiple perls on any pull request, commit, etc.
