### PR TITLE
Allow the uploads directory to be backed up

### DIFF
--- a/script/wp-tools
+++ b/script/wp-tools
@@ -575,7 +575,7 @@ sub backup {
         opendir (my $dh, $wp_content_path) || die;
         while (my $path = readdir $dh) {
             next if $path eq '.' || $path eq '..';
-            if ($path =~ /(?:backup|upload)/i) {
+            if ($path =~ /(?:backup)/i) {
                 $skips->{$path} = $wp_content_size->{$path};
             }
             if ($wp_content_size->{$path} && $wp_content_size->{$path} > 200 && $path !~ /^(?:themes|plugins|mu-plugins|translations|languages)$/) {


### PR DESCRIPTION
Previously, the uploads directory was being skipped even if it was under
the max_size argument. This change will allow the uploads directory to
be backed up if it falls under the given max_size.
