### PR TITLE
Reduce chance of leaving site messed up on restore

### DIFF
--- a/script/wp-tools
+++ b/script/wp-tools
@@ -879,11 +879,20 @@ sub restore {
     if ($@) {
         my $err = $@;
         if (-d $saved_path) {
-            rmtree($path);
-            if (!rename($saved_path, $path)) {
-                # this is the sad case
-                $err .= "; also could not move $saved_path back to $path: $!";
-                undef $saved_path;  # do not wipe out if we couldn't fully fix it
+            my $defunct_path = $path;
+            $defunct_path =~ s!/+$!!;
+            $defunct_path .= ".defunct_" . time;
+            if (rename($path, $defunct_path)) {
+                if (!rename($saved_path, $path)) {
+                    # this is the sad case
+                    $err .= "; also could not move $saved_path back to $path: $!";
+                    undef $saved_path;  # do not wipe out if we couldn't fully fix it
+                    rename($defunct_path, $path);
+                }
+
+                if (-d $defunct_path) {
+                    rmtree($defunct_path);
+                }
             }
         }
         die $err;


### PR DESCRIPTION
This fixes a bug where, if the script is killed at the right moment
during a restore, the site may be left in an inconsistent state.